### PR TITLE
SAC Latent

### DIFF
--- a/stable_baselines3/__init__.py
+++ b/stable_baselines3/__init__.py
@@ -8,6 +8,7 @@ from stable_baselines3.her.her_replay_buffer import HerReplayBuffer
 from stable_baselines3.ppo import PPO
 from stable_baselines3.sac import SAC
 from stable_baselines3.td3 import TD3
+from stable_baselines3.sac_latent import SACLatent
 
 # Read version from file
 version_file = os.path.join(os.path.dirname(__file__), "version.txt")

--- a/stable_baselines3/common/off_policy_algorithm.py
+++ b/stable_baselines3/common/off_policy_algorithm.py
@@ -4,7 +4,6 @@ import time
 import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
-from warnings import warn
 
 import gym
 import numpy as np
@@ -25,7 +24,6 @@ from stable_baselines3.her.her_replay_buffer import HerReplayBuffer
 class OffPolicyAlgorithm(BaseAlgorithm):
     """
     The base for Off-Policy algorithms (ex: SAC/TD3)
-
     :param policy: Policy object
     :param env: The environment to learn from
                 (if registered in Gym, can be str. Can be None for loading trained models)
@@ -235,7 +233,6 @@ class OffPolicyAlgorithm(BaseAlgorithm):
     def save_replay_buffer(self, path: Union[str, pathlib.Path, io.BufferedIOBase]) -> None:
         """
         Save the replay buffer as a pickle file.
-
         :param path: Path to the file where the replay buffer should be saved.
             if path is a str or pathlib.Path, the path is automatically created if necessary.
         """
@@ -249,7 +246,6 @@ class OffPolicyAlgorithm(BaseAlgorithm):
     ) -> None:
         """
         Load a replay buffer from a pickle file.
-
         :param path: Path to the pickled replay buffer.
         :param truncate_last_traj: When using ``HerReplayBuffer`` with online sampling:
             If set to ``True``, we assume that the last trajectory in the replay buffer was finished
@@ -395,7 +391,6 @@ class OffPolicyAlgorithm(BaseAlgorithm):
         This is either done by sampling the probability distribution of the policy,
         or sampling a random action (from a uniform distribution over the action space)
         or by adding noise to the deterministic output.
-
         :param action_noise: Action noise that will be used for exploration
             Required for deterministic policy (e.g. TD3). This can also be used
             in addition to the stochastic policy for SAC.
@@ -417,22 +412,15 @@ class OffPolicyAlgorithm(BaseAlgorithm):
 
         # Rescale the action from [low, high] to [-1, 1]
         if isinstance(self.action_space, gym.spaces.Box):
-            if not np.any(self.action_space.bounded_above) or not np.any(self.action_space.bounded_below):
-                warn('Action space bounds contains +/-inf. Actions will not be scaled.')
-                action = unscaled_action
-                if action_noise is not None:
-                    action = np.clip(action + action_noise(), -1, 1)
-                buffer_action = action
-            else:
-                scaled_action = self.policy.scale_action(unscaled_action)
+            scaled_action = self.policy.scale_action(unscaled_action)
 
-                # Add noise to the action (improve exploration)
-                if action_noise is not None:
-                    scaled_action = np.clip(scaled_action + action_noise(), -1, 1)
+            # Add noise to the action (improve exploration)
+            if action_noise is not None:
+                scaled_action = np.clip(scaled_action + action_noise(), -1, 1)
 
-                # We store the scaled action in the buffer
-                buffer_action = scaled_action
-                action = self.policy.unscale_action(scaled_action)
+            # We store the scaled action in the buffer
+            buffer_action = scaled_action
+            action = self.policy.unscale_action(scaled_action)
         else:
             # Discrete case, no need to normalize or clip
             buffer_action = unscaled_action
@@ -481,7 +469,6 @@ class OffPolicyAlgorithm(BaseAlgorithm):
         Store transition in the replay buffer.
         We store the normalized action and the unnormalized observation.
         It also handles terminal observations (because VecEnv resets automatically).
-
         :param replay_buffer: Replay buffer object where to store the transition.
         :param buffer_action: normalized action
         :param new_obs: next observation in the current episode
@@ -545,7 +532,6 @@ class OffPolicyAlgorithm(BaseAlgorithm):
     ) -> RolloutReturn:
         """
         Collect experiences and store them into a ``ReplayBuffer``.
-
         :param env: The training environment
         :param callback: Callback that will be called at each step
             (and at the beginning and end of the rollout)

--- a/stable_baselines3/common/utils.py
+++ b/stable_baselines3/common/utils.py
@@ -537,3 +537,21 @@ def load_pca_transformation(path_to_dir, latent_dim, native_dim, unsquashed=True
     W_latent.weight.requires_grad = False
 
     return W_latent.type(torch.float), mu_latent.type(torch.float)
+
+def load_pca_transformation_numpy(path_to_dir, latent_dim, native_dim, unsquashed=True):
+
+    assert type(latent_dim) == int
+    assert type(native_dim) == int
+
+    if unsquashed: suffix = "_unsquashed"
+    else: suffix = "_squashed"
+
+    if latent_dim != -1:
+        W = np.load(f'{path_to_dir}/W{suffix}.npy')
+        W = W[:latent_dim, :]
+        mu = np.load(f'{path_to_dir}/mu{suffix}.npy')
+    else:
+        W = np.eye(native_dim)
+        mu = np.zeros(native_dim)
+
+    return W, mu

--- a/stable_baselines3/sac_latent/__init__.py
+++ b/stable_baselines3/sac_latent/__init__.py
@@ -1,0 +1,2 @@
+from stable_baselines3.sac_latent.policies import MlpPolicy
+from stable_baselines3.sac_latent.sac_latent import SACLatent

--- a/stable_baselines3/sac_latent/sac_latent.py
+++ b/stable_baselines3/sac_latent/sac_latent.py
@@ -10,7 +10,7 @@ from stable_baselines3.common.noise import ActionNoise
 from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
 from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
 from stable_baselines3.common.utils import polyak_update
-from algs.sac_latent_policy import SACPolicyLatent
+from stable_baselines3.sac_latent.policies import SACPolicyLatent
 
 """
 Same as SAC but uses SACPolicyLatent instead of SACPolicy
@@ -105,6 +105,8 @@ class SACLatent(OffPolicyAlgorithm):
         device: Union[th.device, str] = "auto",
         _init_setup_model: bool = True,
     ):
+
+        policy_kwargs['env_id'] = env.envs[0].spec.id
 
         super(SACLatent, self).__init__(
             policy,

--- a/stable_baselines3/td3_latent/policies.py
+++ b/stable_baselines3/td3_latent/policies.py
@@ -15,7 +15,7 @@ from stable_baselines3.common.torch_layers import (
     get_actor_critic_arch,
 )
 from stable_baselines3.common.type_aliases import Schedule
-from stable_baselines3.common.utils import load_pca_transformation
+from stable_baselines3.common.utils import get_pca_layer
 
 
 class Actor(BasePolicy):
@@ -57,12 +57,11 @@ class Actor(BasePolicy):
         self.net_arch = net_arch
         self.features_dim = features_dim
         self.activation_fn = activation_fn
-
+        print(latent_dim)
         native_dim = get_action_dim(self.action_space)
-        self.W_latent, self.mu_latent = load_pca_transformation(
+        self.W_latent = get_pca_layer(
             path_to_dir=f'./pca/pca_results/{env_id}',
-            latent_dim=latent_dim,
-            native_dim=native_dim)
+            latent_dim=latent_dim)
         if latent_dim == -1:
             latent_dim = native_dim
 

--- a/stable_baselines3/td3_latent/td3_latent.py
+++ b/stable_baselines3/td3_latent/td3_latent.py
@@ -9,7 +9,7 @@ from stable_baselines3.common.buffers import ReplayBuffer
 from stable_baselines3.common.noise import ActionNoise
 from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
 from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
-from stable_baselines3.common.utils import polyak_update
+from stable_baselines3.common.utils import polyak_update, load_pca_transformation_numpy
 from stable_baselines3.td3.policies import TD3Policy
 from stable_baselines3.td3_latent.policies import TD3LatentPolicy
 
@@ -89,7 +89,16 @@ class TD3Latent(OffPolicyAlgorithm):
         _init_setup_model: bool = True,
     ):
 
-        policy_kwargs['env_id'] = env.envs[0].spec.id
+        env_id = env.envs[0].spec.id
+        policy_kwargs['env_id'] = env_id
+        self.native_dim = env.action_space.shape[0]
+        try:
+            self.latent_dim = policy_kwargs['latent_dim']
+        except:
+            self.latent_dim = self.native_dim
+        if self.latent_dim == -1: self.latent_dim = self.native_dim
+        self.W_latent, self.mu_latent = load_pca_transformation_numpy(f'pca/pca_results/{env_id}', self.latent_dim, self.native_dim, unsquashed=False)
+        # self.mu_latent = self.mu_latent[:, np.newaxis]
 
         super(TD3Latent, self).__init__(
             policy,
@@ -152,8 +161,9 @@ class TD3Latent(OffPolicyAlgorithm):
 
             with th.no_grad():
                 # Select action according to policy and add clipped noise
-                noise = replay_data.actions.clone().data.normal_(0, self.target_policy_noise)
+                noise = replay_data.actions[:,:self.latent_dim].clone().data.normal_(0, self.target_policy_noise)
                 noise = noise.clamp(-self.target_noise_clip, self.target_noise_clip)
+                noise = self.W_latent.T.dot(noise.T).T
                 next_actions = (self.actor_target(replay_data.next_observations) + noise).clamp(-1, 1)
 
                 # Compute the next Q-values: min over all critics targets


### PR DESCRIPTION
* The old SAC Latent applied the PCA decoder prior to sampling, which means that noise can push actions outside of the latent space. Since the latent policy alone cannot generate these actions, this may lead to instability. We don't want to update networks using actions the agent can't even take.
* TD3 Latent still generates noise that can push actions outside of the latent space.